### PR TITLE
updated java dependency check

### DIFF
--- a/orion.rb
+++ b/orion.rb
@@ -5,7 +5,7 @@ class Orion < Formula
   # update with: ./updateOrion.sh <new-version>
   sha256 "ce196ed77ac7914000eecf6ebb7b5f7dc9855ce9bb6774f8d3588f30d2446ddb"
 
-  depends_on "openjdk@8"
+  depends_on "openjdk" => "8+"
 
   def install
     prefix.install "lib"

--- a/orion.rb
+++ b/orion.rb
@@ -1,11 +1,11 @@
 class Orion < Formula
   desc "orion private transaction manager"
-  homepage "https://github.com/pegasyseng/orion"
+  homepage "https://github.com/consensys/orion"
   url "https://consensys.bintray.com/binaries/orion-20.10.0.zip"
   # update with: ./updateOrion.sh <new-version>
   sha256 "905e5ae3460d9b6c694bcc891e7a91869ae3cd4c4c2a4cac333ffede90344da9"
 
-  depends_on :java => "1.8+"
+  depends_on "openjdk@8"
 
   def install
     prefix.install "lib"


### PR DESCRIPTION
Homebrew error with previous syntax

Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/consensys/homebrew-orion/orion.rb
orion: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the consensys/orion tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/consensys/homebrew-orion/orion.rb:8
```